### PR TITLE
Dockerizing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:latest
+
+RUN apt-get update && apt-get -y install python3 python3-pip && apt-get clean
+RUN pip3 install flask
+RUN pip3 install connexion
+RUN pip3 install flask wtforms
+RUN pip3 install kafka
+RUN pip3 install kafka-python
+
+WORKDIR /user/server
+COPY . .
+
+#CMD ["sh","-c","python3","/user/server/app.working.py"]
+RUN tail -f /dev/null

--- a/app.working.py
+++ b/app.working.py
@@ -5,7 +5,7 @@ from wtforms import Form, TextField, TextAreaField, validators, StringField, Sub
 import json
 from kafka import KafkaProducer
 
-producer = KafkaProducer(bootstrap_servers=['localhost:9092'])
+producer = KafkaProducer(bootstrap_servers=['kafka:9092'])
 
 DEBUG = True
 app = Flask(__name__)

--- a/app.working.py
+++ b/app.working.py
@@ -5,7 +5,7 @@ from wtforms import Form, TextField, TextAreaField, validators, StringField, Sub
 import json
 from kafka import KafkaProducer
 
-producer = KafkaProducer(bootstrap_servers=['kafka:9092'])
+producer = KafkaProducer(bootstrap_servers=['localhost:9092'])
 
 DEBUG = True
 app = Flask(__name__)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '2'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
+    logging:
+      driver: "none"
+  kafka:
+    image: wurstmeister/kafka
+    ports:
+      - "9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: host.docker.internal
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_CREATE_TOPICS: "nuix-topic:1:2"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    links:
+      - zookeeper
+    logging:
+      driver: "none"
+  web:
+    build: .
+    ports:
+      - "5000:5000"


### PR DESCRIPTION
**Note:** this is not fully working yet as I did not yet figure out how to get Kafka IP from docker to provide to script.

Created a couple of things:
docker-compose.yml that should spin up a Kafka container and a Zookeeper container and get them talking to each other and also spin up a container running the Python web server based on instructions in Dockerfile.

Dockerfile basically copies project scripts in, gets python installed, pulls down python dependencies and starts the web server via app.working.py.

Note this is not fully working yet as I did not yet figure out how to get Kafka IP from docker to provide to script.

To use you'll want to install Docker desktop.  Then go to repo directory and run `docker up`.